### PR TITLE
feat: Added model configuration options, supporting custom model selection

### DIFF
--- a/info.json
+++ b/info.json
@@ -14,6 +14,11 @@
       "key": "customPrompt",
       "display": "Prompt[可选]",
       "type": "input"
+    },
+    {
+      "key": "model",
+      "display": "模型[可选]",
+      "type": "input"
     }
   ],
   "language": {

--- a/main.js
+++ b/main.js
@@ -1,10 +1,15 @@
 async function recognize(base64, lang, options) {
   const { config, utils } = options;
   const { tauriFetch: fetch, cacheDir, readBinaryFile, http } = utils;
-  let { cookie, customPrompt } = config;
+  let { cookie, customPrompt, model } = config;
 
   if (!cookie) {
     throw new Error("No cookie provided");
+  }
+
+  // 如果沒有設定 model，使用預設值
+  if (!model) {
+    model = "qwen-max-latest";
   }
 
   // 从cookie中提取token
@@ -72,7 +77,7 @@ async function recognize(base64, lang, options) {
       type: "Json",
       payload: {
         stream: false,
-        model: "qwen2.5-vl-72b-instruct",
+        model: model,
         messages: [
           {
             role: "user",


### PR DESCRIPTION
https://github.com/sun-i/pot-app-recognize-plugin-qwen-ocr/blob/62b9c87ee50ccd63a711000d44aec123d32c6363/main.js#L75

以上模型已經無法調用，為了後續方便用戶自行變更模型，在 `info.json` 新增了手動輸入型號的功能，並將預設模型改為 `qwen-max-latest`